### PR TITLE
Add a project plan outline to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,18 @@ NOTE: The following development strategies are suggestions, subject to discussio
 
 ### Suggested code strategy
 
-As much code as possible would be developed via this GitHub repository. The main exceptions would be the code and suites currently developed via [MOSRS](https://code.metoffice.gov.uk/) repositories such as [ANTS](https://code.metoffice.gov.uk/doc/ancil/ants/2.0/index.html), [the ANCIL Contrib project](https://code.metoffice.gov.uk/trac/ancil/browser/contrib/trunk/), Rose/Cylc suites, and Rose Stem tests. These would initially be developed via [contributing](https://code.metoffice.gov.uk/doc/ancil/ants/2.0/contributing.html) to the relevant MOSRS repository according to [current ANTS working practices](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices) and would be migrated to GitHub when appropriate. The GitHub Continuous Integration infrastructure for such MORSR code would be developed in parallel with the code development via MOSRS.
+As much code as possible would be developed via this GitHub repository. The main exceptions would be the code and suites currently developed via [MOSRS](https://code.metoffice.gov.uk/) repositories such as [ANTS](https://code.metoffice.gov.uk/doc/ancil/ants/2.0/index.html), [the ANCIL Contrib project](https://code.metoffice.gov.uk/trac/ancil/browser/contrib/trunk/), Rose/Cylc suites, and Rose Stem tests. These would initially be developed via [contributing](https://code.metoffice.gov.uk/doc/ancil/ants/2.0/contributing.html) to the relevant MOSRS repository according to [current ANTS working practices](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices) and would be migrated to GitHub when appropriate. The GitHub Continuous Integration infrastructure for such MOSRS code would be developed in parallel with the code development via MOSRS.
 
 ### Suggested documentation strategy
 
 Similarly, as much documentation as possible would be contained in the Wiki for this repository, then published to other locations when appropriate. The main exception would be documentation that describes some of the internal workings of some UK Met Office and Momentum Partnership projects, such as [the ANCIL project](https://code.metoffice.gov.uk/trac/ancil), [the UK CMIP6 project](https://code.metoffice.gov.uk/trac/ukcmip6), and [the UKESM project](https://code.metoffice.gov.uk/trac/UKESM).  In this case, only a top-level description would be given in the Wiki for this repository, with details in an appropriate MOSRS project Wiki.  
+
+## Suggested project plan outline with major milestones
+
+1. Document the correspondence between CMIP6 DECK forcings and ESM1.5 or ESM1.6 input files.
+2. CMIP6 and CMIP7 DECK ancillary suite for ACCESS-ESM1.6, using updated Python scripts for ancillary generation.
+3. CMIP7 DECK ancillary suite for ACCESS-*M3.
+4. CMIP7 ancillary suite for CMIP7 MIPs for ACCESS-ESM1.6.
+5. CMIP7 ancillary suite for CMIP7 MIPs for ACCESS-*M3.
+
+Each of these milestones is to be broken down into goals, subgoals, and project items.


### PR DESCRIPTION
The project plan outline is just a skeleton, containing milestones only. Each milestone would then be made into an issue.