### PR TITLE
Added pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: main
+    paths:
+      - 'CMIP7/**'
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    -   id: check-yaml
+    -   id: check-toml
+    -   id: name-tests-test
+    -   id: debug-statements
+    -   id: requirements-txt-fixer
+# Run linter and formatter.
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: 'v0.12.4'
+    hooks:
+    # Run the linter
+    -   id: ruff-check
+        types_or: [ python, pyi ] # Exclude jupyter notebooks
+        args: ['--fix']
+    -   id: ruff-format
+        types_or: [ python, pyi ] # Exclude jupyter notebooks
+# Run the type checker.
+# -   repo: https://github.com/pre-commit/mirrors-mypy
+#     rev: 'v1.17.0'
+#     hooks:
+#     -   id: mypy
+#         name: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,3 @@ repos:
         args: ['--fix']
     -   id: ruff-format
         types_or: [ python, pyi ] # Exclude jupyter notebooks
-# Run the type checker.
-# -   repo: https://github.com/pre-commit/mirrors-mypy
-#     rev: 'v1.17.0'
-#     hooks:
-#     -   id: mypy
-#         name: mypy

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
@@ -206,7 +206,7 @@ def remap_vegetation(InputDataset, InputVegetation, OutputVegetation, Config):
                                       PerTileVariables)
 
     # Add the land fractions- also include previous year as same for LUC
-    OutDataset['FRACTIONS OF SURFACE TYPES'] = (('veg', 'lat', 'lon'),NewVegetation)
+    OutDataset['FRACTIONS OF SURFACE TYPES'] = (('veg', 'lat', 'lon'), NewVegetation)
     OutDataset['PREVIOUS YEAR SURF FRACTIONS (TILES)'] = (('veg', 'lat', 'lon'), NewVegetation)
 
     # Perform the per-cell averaging

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
@@ -206,10 +206,8 @@ def remap_vegetation(InputDataset, InputVegetation, OutputVegetation, Config):
                                       PerTileVariables)
 
     # Add the land fractions- also include previous year as same for LUC
-    OutDataset['FRACTIONS OF SURFACE TYPES'] = (('veg', 'lat', 'lon'),
-                                               NewVegetation)
-    OutDataset['PREVIOUS YEAR SURF FRACTIONS (TILES)'] = \
-        (('veg', 'lat', 'lon'), NewVegetation)
+    OutDataset['FRACTIONS OF SURFACE TYPES'] = (('veg', 'lat', 'lon'),NewVegetation)
+    OutDataset['PREVIOUS YEAR SURF FRACTIONS (TILES)'] = (('veg', 'lat', 'lon'), NewVegetation)
 
     # Perform the per-cell averaging
     # Apply a mask to the array, so we don't mess up our summations with

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
@@ -206,8 +206,10 @@ def remap_vegetation(InputDataset, InputVegetation, OutputVegetation, Config):
                                       PerTileVariables)
 
     # Add the land fractions- also include previous year as same for LUC
-    OutDataset['FRACTIONS OF SURFACE TYPES'] = (('veg', 'lat', 'lon'), NewVegetation)
-    OutDataset['PREVIOUS YEAR SURF FRACTIONS (TILES)'] = (('veg', 'lat', 'lon'), NewVegetation)
+    OutDataset['FRACTIONS OF SURFACE TYPES'] = (('veg', 'lat', 'lon'),
+                                               NewVegetation)
+    OutDataset['PREVIOUS YEAR SURF FRACTIONS (TILES)'] = \
+        (('veg', 'lat', 'lon'), NewVegetation)
 
     # Perform the per-cell averaging
     # Apply a mask to the array, so we don't mess up our summations with

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+
 # CMIP7-Input: Code and documentation for ACCESS CMIP7 forcings and input files
 
 This repository is intended for code and documentation related to the input data used by the ACCESS models used for CMIP7, notably [ACCESS-ESM1.6](https://github.com/ACCESS-NRI/access-esm1.6-configs) and [ACCESS-CM3](https://github.com/ACCESS-NRI/cm3-suite). This includes code and documentation related to transformations applied to [CMIP7 forcing files](https://wcrp-cmip.org/cmip7-task-teams/forcings/) to produce model input files for each CMIP7 experiment.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,56 @@
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+line-length = 120
+indent-width = 4
+
+[lint]
+# E402: module level import not at top of file
+ignore = [
+    "E402",
+]
+select = [
+    # Pyflakes
+    "F",
+    # Pycodestyle
+    "E",
+    "W",
+    # isort
+    "I",
+    # Pyupgrade
+    "UP",
+    # mccabe
+    "C90",
+]
+
+[format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+docstring-code-format = false

--- a/ruff.toml
+++ b/ruff.toml
@@ -25,6 +25,7 @@ exclude = [
     "node_modules",
     "site-packages",
     "venv",
+    "examples",
 ]
 
 line-length = 120


### PR DESCRIPTION
- [x] Added pre-commit hooks for linting and formatting using Ruff, that trigger on pushes to `main` and PRs, only if changes include files in the CMIP7 folder.
- [x] Added ruff.toml for ruff configuration. Once the project has a pyproject.toml, this configuration can be embedded there.
