### PR TITLE
Forgot to import argparse when adding CLI args to script

### DIFF
--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/add_netcdf_fields_to_UM_restart.py
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/add_netcdf_fields_to_UM_restart.py
@@ -117,7 +117,7 @@ if __name__ == '__main__':
         SMBase.update(SM)
 
     BaseRestart = mule.FieldsFile.from_file(args.restart)
-    BaseRestart.attach_stashmaster_info(STASHmasterBase.by_section(0))
+    BaseRestart.attach_stashmaster_info(SMBase.by_section(0))
 
     # Drop in the variables to modify
     for Variable in Dataset.data_vars:

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/add_netcdf_fields_to_UM_restart.py
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/add_netcdf_fields_to_UM_restart.py
@@ -126,4 +126,4 @@ if __name__ == '__main__':
     # Write to file- since the UM7 restart doesn't match their expected format
     # for some reason, we need to override the existing to_file
     BaseRestart.to_file = to_file
-    BaseRestart.to_file(BaseRestartFile, args.output)
+    BaseRestart.to_file(BaseRestart, args.output)

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/add_netcdf_fields_to_UM_restart.py
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/add_netcdf_fields_to_UM_restart.py
@@ -1,6 +1,7 @@
 import xarray
 import mule
 import six
+import argparse
 
 def _parse_args():
     """Read the command line arguments."""

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
@@ -208,7 +208,7 @@ def remap_vegetation(InputDataset, InputVegetation, OutputVegetation, Config):
     # Add the land fractions- also include previous year as same for LUC
     OutDataset['FRACTIONS OF SURFACE TYPES'] = (('veg', 'lat', 'lon'),
                                                NewVegetation)
-    OutDataset['PREVIOUS YEAR SURF FRACTIONS (TILES)'] =
+    OutDataset['PREVIOUS YEAR SURF FRACTIONS (TILES)'] = \
         (('veg', 'lat', 'lon'), NewVegetation)
 
     # Perform the per-cell averaging

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/remap_vegetation.py
@@ -214,7 +214,7 @@ def remap_vegetation(InputDataset, InputVegetation, OutputVegetation, Config):
     # Perform the per-cell averaging
     # Apply a mask to the array, so we don't mess up our summations with
     # near-zero vegetation fractions
-    InputVegetation = numpy.ma.masked_less(InputVegetation, 1e-3)
+    InputVegetation = numpy.ma.masked_less(InputVegetation, 1e-6)
 
     for Variable in PerCellVariables:
         res = numpy.sum(InputDataset[Variable].to_numpy() * InputVegetation, axis=0)

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
@@ -11,7 +11,7 @@ module use /g/data/xp65/public/modules
 module load conda/analysis3-25.08
 
 reference_restart=""    # UM restart to use as a start point
-restart_as_netcdf=""    # Intermediate NetCDF file to gold the CABLE relevant fields
+restart_as_netcdf=""    # Intermediate NetCDF file to hold the CABLE relevant fields
 new_vegetation_dist=""  # New vegetation distribution to substitute in
 remap_config=""         # Config file to configure the remapping
 remapped_restart_as_netcdf=""  # Remapped CABLE fields 

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
@@ -8,7 +8,7 @@
 #PBS -l wd
 
 module use /g/data/xp65/public/modules
-module load conda/analysis3
+module load conda/analysis3-25.08
 
 reference_restart=""
 restart_as_netcdf=""

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
@@ -8,7 +8,7 @@
 #PBS -l wd
 
 module use /g/data/xp65/public/modules
-module load conda/analysis3-24.0
+module load conda/analysis3
 
 reference_restart=""
 restart_as_netcdf=""

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
@@ -21,4 +21,4 @@ output_restart=""
 
 python convert_UM_restart_to_netcdf.py -i ${reference_restart} -o ${restart_as_netcdf}
 python remap_vegetation.py -i ${restart_as_netcdf} -o ${remapped_restart_as_netcdf} -m ${new_vegetation_dist} -c ${remap_config}
-python add_netcdf_fields_to_UM_restart.py -i ${remapped_restart_as_netcdf} -o ${output_restart}
+python add_netcdf_fields_to_UM_restart.py -i ${remapped_restart_as_netcdf} -o ${output_restart} -r ${reference_restart}

--- a/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
+++ b/CMIP7/esm1p6/spinup/atmosphere/land/generate_restart_from_vegetation_distribution/run_remap.sh
@@ -10,12 +10,12 @@
 module use /g/data/xp65/public/modules
 module load conda/analysis3-25.08
 
-reference_restart=""
-restart_as_netcdf=""
-new_vegetation_dist=""
-remap_config=""
-remapped_restart_as_netcdf=""
-output_restart=""
+reference_restart=""    # UM restart to use as a start point
+restart_as_netcdf=""    # Intermediate NetCDF file to gold the CABLE relevant fields
+new_vegetation_dist=""  # New vegetation distribution to substitute in
+remap_config=""         # Config file to configure the remapping
+remapped_restart_as_netcdf=""  # Remapped CABLE fields 
+output_restart=""       # Name to write the new restart to
 
 # Add the -s/--stash arguments to scripts 1 and 3 if you don't have access to the defaults
 


### PR DESCRIPTION
Turns out there were a few things that I missed when trying to generalise the routines.

* Forgot to import argparse in the "add_netcdf_fields_to_UM_restart.py".
* Call a more up-to-date version of the xp65 module.
* Reduce minimum threshold for vegetation fraction to 1e-6 from 1e-3.
* Missed some variable name changes that came with importing arguments in "add_netcdf_fields_to_UM_restart.py".