### PR TITLE
Add CO2 emissions forcing for esm-hist

### DIFF
--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_aerosol_anthro.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_aerosol_anthro.py
@@ -31,8 +31,8 @@ def parse_args(species):
 def load_cmip7_hi_aerosol_air_anthro(
     args,
     species,
-    beg_year=CMIP7_HI_BEG_YEAR,
-    end_year=CMIP7_HI_END_YEAR,
+    beg_year=CMIP7_HI_AEROSOL_BEG_YEAR,
+    end_year=CMIP7_HI_AEROSOL_END_YEAR,
 ):
     return load_cmip7_aerosol_air_anthro_list(
         args,

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_aerosol_anthro.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_aerosol_anthro.py
@@ -3,6 +3,7 @@ from ast import literal_eval
 
 from aerosol.cmip7_aerosol_anthro import (
     cmip7_aerosol_anthro_interpolate,
+    load_cmip7_aerosol_air_anthro_list,
     load_cmip7_aerosol_anthro_list,
 )
 from aerosol.cmip7_HI_aerosol import (
@@ -25,6 +26,20 @@ def parse_args(species):
     parser.add_argument("--dataset-date-range-list", type=literal_eval)
     parser.add_argument("--save-filename")
     return parser.parse_args()
+
+
+def load_cmip7_hi_aerosol_air_anthro(
+    args,
+    species,
+    beg_year=CMIP7_HI_BEG_YEAR,
+    end_year=CMIP7_HI_END_YEAR,
+):
+    return load_cmip7_aerosol_air_anthro_list(
+        args,
+        species,
+        args.dataset_date_range_list,
+        cmip7_date_constraint_from_years(beg_year, end_year),
+    )
 
 
 def load_cmip7_hi_aerosol_anthro(

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_anthro.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_anthro.py
@@ -24,6 +24,22 @@ def cmip7_aerosol_anthro_rootpath(args):
     )
 
 
+def cmip7_aerosol_air_anthro_filepath(args, species, date_range):
+    rootpath = cmip7_aerosol_anthro_rootpath(args)
+    filename = (
+        f"{species}-em-AIR-anthro_input4MIPs_emissions_CMIP_"
+        f"{args.dataset_version}_gn_"
+        f"{date_range}.nc"
+    )
+    return (
+        rootpath
+        / f"{species}_em_AIR_anthro"
+        / "gn"
+        / args.dataset_vdate
+        / filename
+    )
+
+
 def cmip7_aerosol_anthro_filepath(args, species, date_range):
     rootpath = cmip7_aerosol_anthro_rootpath(args)
     filename = (
@@ -36,13 +52,6 @@ def cmip7_aerosol_anthro_filepath(args, species, date_range):
     )
 
 
-def cmip7_aerosol_anthro_filepath_list(args, species, date_range_list):
-    return [
-        cmip7_aerosol_anthro_filepath(args, species, date_range)
-        for date_range in date_range_list
-    ]
-
-
 def load_cmip7_aerosol_anthro(args, species, date_range, constraint):
     cube = load_cmip7_aerosol(
         args, cmip7_aerosol_anthro_filepath, species, date_range, constraint
@@ -51,10 +60,24 @@ def load_cmip7_aerosol_anthro(args, species, date_range, constraint):
     return cube
 
 
+def load_cmip7_aerosol_air_anthro_list(
+    args, species, date_range_list, constraint
+):
+    cube = load_cmip7_aerosol_list(
+        args,
+        cmip7_aerosol_air_anthro_filepath,
+        species,
+        date_range_list,
+        constraint,
+    )
+    fix_coords(args, cube)
+    return cube
+
+
 def load_cmip7_aerosol_anthro_list(args, species, date_range_list, constraint):
     cube = load_cmip7_aerosol_list(
         args,
-        cmip7_aerosol_anthro_filepath_list,
+        cmip7_aerosol_anthro_filepath,
         species,
         date_range_list,
         constraint,

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_biomass.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_biomass.py
@@ -36,13 +36,6 @@ def cmip7_aerosol_biomass_filepath(args, species, date_range):
     return rootpath / species / "gn" / args.dataset_vdate / filename
 
 
-def cmip7_aerosol_biomass_filepath_list(args, species, date_range_list):
-    return [
-        cmip7_aerosol_biomass_filepath(args, species, date_range)
-        for date_range in date_range_list
-    ]
-
-
 def load_cmip7_aerosol_biomass(args, species, date_range, constraint):
     cube = load_cmip7_aerosol(
         args, cmip7_aerosol_biomass_filepath, species, date_range, constraint
@@ -56,7 +49,7 @@ def load_cmip7_aerosol_biomass(args, species, date_range, constraint):
 def load_cmip7_aerosol_biomass_list(args, species, date_range_list, constraint):
     cube = load_cmip7_aerosol_list(
         args,
-        cmip7_aerosol_biomass_filepath_list,
+        cmip7_aerosol_biomass_filepath,
         species,
         date_range_list,
         constraint,

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_common.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_common.py
@@ -8,10 +8,18 @@ def load_cmip7_aerosol(args, filepath_fn, species, date_range, constraint):
     return cube
 
 
+def cmip7_aerosol_filepath_list(args, filepath_fn, species, date_range_list):
+    return [
+        filepath_fn(args, species, date_range) for date_range in date_range_list
+    ]
+
+
 def load_cmip7_aerosol_list(
-    args, filepath_list_fn, species, date_range_list, constraint
+    args, filepath_fn, species, date_range_list, constraint
 ):
-    filepath_list = filepath_list_fn(args, species, date_range_list)
+    filepath_list = cmip7_aerosol_filepath_list(
+        args, filepath_fn, species, date_range_list
+    )
     cube_list = iris.load_raw(filepath_list, constraint)
     equalise_attributes(cube_list)
     unify_time_units(cube_list)

--- a/CMIP7/esm1p6/atmosphere/co2/cmip7_EH_CO2_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/co2/cmip7_EH_CO2_interpolate.py
@@ -1,0 +1,70 @@
+# Interpolate CMIP7 EH CO2 emissions to ESM1.6 grid
+from pathlib import Path
+
+import iris
+from aerosol.cmip7_aerosol_common import zero_poles
+from aerosol.cmip7_HI_aerosol_anthro import (
+    load_cmip7_hi_aerosol_air_anthro,
+    load_cmip7_hi_aerosol_anthro,
+    parse_args,
+)
+from cmip7_ancil_common import (
+    INTERPOLATION_SCHEME,
+    esm_grid_mask_cube,
+    save_ancil,
+)
+from cmip7_ancil_constants import ANCIL_TODAY
+from cmip7_HI import CMIP7_HI_BEG_YEAR, CMIP7_HI_END_YEAR
+
+SPECIES = "CO2"
+STASH_ITEM = 251
+# The CO2 time series includes 1849 and 2023,
+# so use these years directly from the datasets.
+CMIP7_HI_CO2_BEG_YEAR = CMIP7_HI_BEG_YEAR - 1
+CMIP7_HI_CO2_END_YEAR = CMIP7_HI_END_YEAR + 1
+
+
+def esm_eh_co2_save_dirpath(args):
+    return (
+        Path(args.ancil_target_dirname)
+        / "modern"
+        / "historical-emissions"
+        / "atmosphere"
+        / "forcing"
+        / args.esm_grid_rel_dirname
+        / ANCIL_TODAY
+    )
+
+
+def cmip7_eh_co2_anthro_interpolate(args):
+    cube = load_cmip7_hi_aerosol_anthro(
+        args,
+        SPECIES,
+        beg_year=CMIP7_HI_CO2_BEG_YEAR,
+        end_year=CMIP7_HI_CO2_END_YEAR,
+    )
+    cube_sum = cube.collapsed(["sector"], iris.analysis.SUM)
+    cube_air = load_cmip7_hi_aerosol_air_anthro(
+        args,
+        SPECIES,
+        beg_year=CMIP7_HI_CO2_BEG_YEAR,
+        end_year=CMIP7_HI_CO2_END_YEAR,
+    )
+    cube_air_sum = cube_air.collapsed(["altitude"], iris.analysis.SUM)
+    cube_tot = cube_sum + cube_air_sum
+
+    esm_cube = cube_tot.regrid(esm_grid_mask_cube(args), INTERPOLATION_SCHEME)
+    esm_cube.data = esm_cube.data.filled(0.0)
+    zero_poles(esm_cube)
+    esm_cube.attributes["STASH"] = iris.fileformats.pp.STASH(
+        model=1, section=0, item=STASH_ITEM
+    )
+
+    save_dirpath = esm_eh_co2_save_dirpath(args)
+    save_ancil(esm_cube, save_dirpath, args.save_filename)
+
+
+if __name__ == "__main__":
+    args = parse_args(species=SPECIES)
+
+    cmip7_eh_co2_anthro_interpolate(args)


### PR DESCRIPTION
Closes #112 

Tested using the [u-dq819/112-esm-hist@342286](https://code.metoffice.gov.uk/trac/roses-u/browser/d/q/8/1/9/112-esm-hist?rev=342286) workflow. Workflow output is at `gadi:/scratch/tm70/pcl851/cylc-run/u-dq819.112-esm-hist/run1`. Ancillary output is at `gadi:/g/data/tm70/pcl851/CMIP7/esm1p6_ancil/2025.12.23/modern/historical-emissions/atmosphere/forcing/global.N96/2025.12.23/CO2_fluxes_1849_2023_cmip7.anc`. Please pay attention to the calendar and dates in the ancillary file.
