### PR TITLE
Use historical aerosol data for 1849 and 2023

### DIFF
--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_Bio_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_Bio_interpolate.py
@@ -8,13 +8,16 @@ from aerosol.cmip7_aerosol_biomass import (
     load_cmip7_aerosol_biomass_list,
     save_cmip7_aerosol_biomass,
 )
-from aerosol.cmip7_HI_aerosol import esm_hi_aerosol_save_dirpath
+from aerosol.cmip7_HI_aerosol import (
+    CMIP7_HI_AEROSOL_BEG_YEAR,
+    CMIP7_HI_AEROSOL_END_YEAR,
+    esm_hi_aerosol_save_dirpath,
+)
 from cmip7_ancil_argparse import (
     common_parser,
     percent_parser,
 )
 from cmip7_ancil_common import cmip7_date_constraint_from_years
-from cmip7_HI import CMIP7_HI_BEG_YEAR, CMIP7_HI_END_YEAR
 
 
 def parse_args():
@@ -39,8 +42,8 @@ def load_cmip7_hi_aerosol_biomass(args, species):
         species,
         args.dataset_date_range_list,
         cmip7_date_constraint_from_years(
-            CMIP7_HI_BEG_YEAR,
-            CMIP7_HI_END_YEAR,
+            CMIP7_HI_AEROSOL_BEG_YEAR,
+            CMIP7_HI_AEROSOL_END_YEAR,
         ),
     )
 
@@ -51,8 +54,8 @@ def load_cmip7_hi_aerosol_biomass_percentage(args, species):
         species,
         args.percent_date_range,
         cmip7_date_constraint_from_years(
-            CMIP7_HI_BEG_YEAR,
-            CMIP7_HI_END_YEAR,
+            CMIP7_HI_AEROSOL_BEG_YEAR,
+            CMIP7_HI_AEROSOL_END_YEAR,
         ),
     )
 

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_SO2_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_SO2_interpolate.py
@@ -4,6 +4,8 @@ from argparse import ArgumentParser
 from ast import literal_eval
 
 from aerosol.cmip7_HI_aerosol import (
+    CMIP7_HI_AEROSOL_BEG_YEAR,
+    CMIP7_HI_AEROSOL_END_YEAR,
     esm_hi_aerosol_ancil_dirpath,
     esm_hi_aerosol_save_dirpath,
 )
@@ -16,11 +18,7 @@ from cmip7_ancil_argparse import (
     common_parser,
     dms_filename_parser,
 )
-from cmip7_HI import (
-    CMIP7_HI_BEG_YEAR,
-    CMIP7_HI_END_YEAR,
-    fix_esm15_hi_ancil_date,
-)
+from cmip7_HI import fix_esm15_hi_ancil_date
 
 
 def parse_args():
@@ -43,8 +41,8 @@ def load_cmip7_hi_so2_aerosol_anthro(args, species):
     return load_cmip7_hi_aerosol_anthro(
         args,
         species,
-        beg_year=CMIP7_HI_BEG_YEAR,
-        end_year=CMIP7_HI_END_YEAR,
+        beg_year=CMIP7_HI_AEROSOL_BEG_YEAR,
+        end_year=CMIP7_HI_AEROSOL_END_YEAR,
     )
 
 

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_aerosol.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_aerosol.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
 from cmip7_ancil_constants import ANCIL_TODAY
+from cmip7_HI import CMIP7_HI_BEG_YEAR, CMIP7_HI_END_YEAR
+
+CMIP7_HI_AEROSOL_BEG_YEAR = CMIP7_HI_BEG_YEAR - 1
+CMIP7_HI_AEROSOL_END_YEAR = CMIP7_HI_END_YEAR + 1
 
 
 def esm_hi_aerosol_ancil_dirpath(ancil_root_dirname):

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_aerosol_anthro.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_HI_aerosol_anthro.py
@@ -5,10 +5,13 @@ from aerosol.cmip7_aerosol_anthro import (
     cmip7_aerosol_anthro_interpolate,
     load_cmip7_aerosol_anthro_list,
 )
-from aerosol.cmip7_HI_aerosol import esm_hi_aerosol_save_dirpath
+from aerosol.cmip7_HI_aerosol import (
+    CMIP7_HI_AEROSOL_BEG_YEAR,
+    CMIP7_HI_AEROSOL_END_YEAR,
+    esm_hi_aerosol_save_dirpath,
+)
 from cmip7_ancil_argparse import common_parser
 from cmip7_ancil_common import cmip7_date_constraint_from_years
-from cmip7_HI import CMIP7_HI_BEG_YEAR, CMIP7_HI_END_YEAR
 
 
 def parse_args(species):
@@ -27,8 +30,8 @@ def parse_args(species):
 def load_cmip7_hi_aerosol_anthro(
     args,
     species,
-    beg_year=CMIP7_HI_BEG_YEAR,
-    end_year=CMIP7_HI_END_YEAR,
+    beg_year=CMIP7_HI_AEROSOL_BEG_YEAR,
+    end_year=CMIP7_HI_AEROSOL_END_YEAR,
 ):
     return load_cmip7_aerosol_anthro_list(
         args,

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_SO2_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_SO2_interpolate.py
@@ -12,7 +12,6 @@ from aerosol.cmip7_aerosol_common import zero_poles
 from cmip7_ancil_common import (
     INTERPOLATION_SCHEME,
     esm_grid_mask_cube,
-    extend_years,
     save_ancil,
 )
 
@@ -98,11 +97,6 @@ def save_cmip7_so2_aerosol_anthro(
     # Need to remove the sector coordinate before saving
     # because high doesn't have it
     so2_low.remove_coord("sector")
-
-    # Extend the historical time series, if any,
-    # by duplicating the first and last years
-    so2_low = extend_years(so2_low)
-    so2_high = extend_years(so2_high)
 
     # Use the CMIP6 DMS
     cmip6_dms = dms_load_fn(args)

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_anthro.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_anthro.py
@@ -9,7 +9,6 @@ from aerosol.cmip7_aerosol_common import (
 from cmip7_ancil_common import (
     INTERPOLATION_SCHEME,
     esm_grid_mask_cube,
-    extend_years,
     fix_coords,
     save_ancil,
 )
@@ -75,7 +74,4 @@ def cmip7_aerosol_anthro_interpolate(
     esm_cube.attributes["STASH"] = iris.fileformats.pp.STASH(
         model=1, section=0, item=stash_item
     )
-    # Extend the historical time series, if any,
-    # by duplicating the first and last years
-    esm_cube = extend_years(esm_cube)
     save_ancil(esm_cube, save_dirpath, args.save_filename)

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_biomass.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_biomass.py
@@ -11,7 +11,6 @@ from aerosol.cmip7_aerosol_common import (
 from cmip7_ancil_common import (
     INTERPOLATION_SCHEME,
     esm_grid_mask_cube,
-    extend_years,
     save_ancil,
     set_coord_system,
 )
@@ -140,11 +139,6 @@ def save_cmip7_aerosol_biomass(args, load_pc_fn, load_fn, save_dirpath):
     high_esm.attributes["STASH"] = iris.fileformats.pp.STASH(
         model=1, section=0, item=131
     )
-
-    # Extend the historical time series, if any,
-    # by duplicating the first and last years
-    low_esm = extend_years(low_esm)
-    high_esm = extend_years(high_esm)
 
     save_ancil([low_esm, high_esm], save_dirpath, args.save_filename)
 


### PR DESCRIPTION
Closes #116 again. See also #117 for the previous pull request. The difference is that this change uses years 1849 and 2023 from the datasets, instead of duplicating 1850 and 2022.

