### PR TITLE
Add the PI_mean ozone script to the collection of ozone scripts

### DIFF
--- a/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
+++ b/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
@@ -44,7 +44,7 @@ def save_cmip7_pi_mean_ozone(args, cube):
     # Aggregate by "month" to obtain a mean for each month.
     cube = cube.aggregated_by("month", iris.analysis.MEAN, climatological=True)
     # Remove the added "month" coordinate before saving.
-    cube.remove_coordinate("month")
+    cube.remove_coord("month")
     # Save as an ancillary file
     save_dirpath = esm_pi_ozone_save_dirpath(args)
     save_ancil(cube, save_dirpath, args.save_filename, gregorian=False)

--- a/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
+++ b/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
@@ -40,7 +40,9 @@ def esm_pi_ozone_save_dirpath(args):
 
 def save_cmip7_pi_mean_ozone(args, cube):
     # Add a "month_number" variable.
-    iris.coord_categorisation.add_month_number(cube, "time", name="month")
+    iris.coord_categorisation.add_month_number(
+        cube, "time", name="month_number"
+    )
     # Aggregate by "month_number" to obtain a mean for each month.
     cube = cube.aggregated_by("month_number", iris.analysis.MEAN)
     # Re-create the time bounds to ensure that time is contiguous.

--- a/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
+++ b/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
@@ -42,7 +42,7 @@ def save_cmip7_pi_mean_ozone(args, cube):
     # Add a categorical "month" variable.
     iris.coord_categorisation.add_month(cube, "time", name="month")
     # Aggregate by "month" to obtain a mean for each month.
-    cube = cube.aggregated_by("month", iris.analysis.MEAN)
+    cube = cube.aggregated_by("month", iris.analysis.MEAN, climatological=True)
     # Remove the added "month" coordinate before saving.
     cube.remove_coodinate("month")
     # Save as an ancillary file

--- a/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
+++ b/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
@@ -49,8 +49,8 @@ def save_cmip7_pi_mean_ozone(args, cube):
     time = cube.coord("time")
     time.bounds = None
     time.guess_bounds(bound_position=0.5)
-    # Remove the added "month" coordinate before saving.
-    cube.remove_coord("month")
+    # Remove the added "month_number" coordinate before saving.
+    cube.remove_coord("month_number")
     # Save as an ancillary file
     save_dirpath = esm_pi_ozone_save_dirpath(args)
     save_ancil(cube, save_dirpath, args.save_filename, gregorian=False)

--- a/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
+++ b/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
@@ -39,10 +39,14 @@ def esm_pi_ozone_save_dirpath(args):
 
 
 def save_cmip7_pi_mean_ozone(args, cube):
-    # Add a categorical "month" variable.
-    iris.coord_categorisation.add_month(cube, "time", name="month")
-    # Aggregate by "month" to obtain a mean for each month.
-    cube = cube.aggregated_by("month", iris.analysis.MEAN, climatological=True)
+    # Add a "month_number" variable.
+    iris.coord_categorisation.add_month_number(cube, "time", name="month")
+    # Aggregate by "month_number" to obtain a mean for each month.
+    cube = cube.aggregated_by("month_number", iris.analysis.MEAN)
+    # Re-create the time bounds to ensure that time is contiguous.
+    time = cube.coord("time")
+    time.bounds = None
+    time.guess_bounds(bound_position=0.5)
     # Remove the added "month" coordinate before saving.
     cube.remove_coord("month")
     # Save as an ancillary file

--- a/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
+++ b/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
@@ -44,7 +44,7 @@ def save_cmip7_pi_mean_ozone(args, cube):
     # Aggregate by "month" to obtain a mean for each month.
     cube = cube.aggregated_by("month", iris.analysis.MEAN, climatological=True)
     # Remove the added "month" coordinate before saving.
-    cube.remove_coodinate("month")
+    cube.remove_coordinate("month")
     # Save as an ancillary file
     save_dirpath = esm_pi_ozone_save_dirpath(args)
     save_ancil(cube, save_dirpath, args.save_filename, gregorian=False)

--- a/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
+++ b/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
@@ -1,0 +1,57 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+import iris.coord_categorisation
+from cmip7_ancil_argparse import (
+    grid_parser,
+    path_parser,
+)
+from cmip7_ancil_common import save_ancil
+from cmip7_ancil_constants import ANCIL_TODAY
+from ozone.cmip7_ozone import (
+    fix_cmip7_ozone,
+    load_cmip7_ozone,
+    ozone_parser,
+)
+
+
+def parse_args():
+    parser = ArgumentParser(
+        parents=[path_parser(), grid_parser(), ozone_parser()],
+        prog="cmip7_PI_mean_ozone_generate",
+        description=(
+            "Generate input files from 21 year mean of UK CMIP7 historical"
+            "ozone forcings"
+        ),
+    )
+    return parser.parse_args()
+
+
+def esm_pi_ozone_save_dirpath(args):
+    return (
+        Path(args.ancil_target_dirname)
+        / "modern"
+        / "pre-industrial-mean"
+        / "forcing"
+        / args.esm_grid_rel_dirname
+        / ANCIL_TODAY
+    )
+
+
+def save_cmip7_pi_mean_ozone(args, cube):
+    iris.coord_categorisation.add_month(cube, "time", name="month")
+    cube = cube.aggregated_by("month", iris.analysis.MEAN)
+    # Save as an ancillary file
+    save_dirpath = esm_pi_ozone_save_dirpath(args)
+    save_ancil(cube, save_dirpath, args.save_filename, gregorian=False)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    # Load the CMIP7 datasets
+    ozone_cube = load_cmip7_ozone(args)
+    # Match the ESM1.5 mask
+    esm_cube = fix_cmip7_ozone(args, ozone_cube)
+    # Save the ancillary
+    save_cmip7_pi_mean_ozone(args, esm_cube)

--- a/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
+++ b/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py
@@ -39,8 +39,12 @@ def esm_pi_ozone_save_dirpath(args):
 
 
 def save_cmip7_pi_mean_ozone(args, cube):
+    # Add a categorical "month" variable.
     iris.coord_categorisation.add_month(cube, "time", name="month")
+    # Aggregate by "month" to obtain a mean for each month.
     cube = cube.aggregated_by("month", iris.analysis.MEAN)
+    # Remove the added "month" coordinate before saving.
+    cube.remove_coodinate("month")
     # Save as an ancillary file
     save_dirpath = esm_pi_ozone_save_dirpath(args)
     save_ancil(cube, save_dirpath, args.save_filename, gregorian=False)


### PR DESCRIPTION
See also pull request #111 and https://code.metoffice.gov.uk/trac/roses-u/browser/d/q/8/1/9/ozone-pi-mean . 

Once the current pull request has been merged, the code will contain [cmip7_PI_mean_ozone_generate.py](https://github.com/ACCESS-NRI/CMIP7-Input/blob/50-ozone-pi-mean/CMIP7/esm1p6/atmosphere/ozone/cmip7_PI_mean_ozone_generate.py) which produces an ancillary 12 months of ozone data by taking the mean aggregated by month of its input dataset. The input is assumed to be the multi year output of the `PI_mean_ukesm_ancil_ozone` task.