### PR TITLE
Add Python code for AMIP ancillary generation

### DIFF
--- a/CMIP7/esm1p6/atmosphere/amip/cmip7_AM_amip_generate.py
+++ b/CMIP7/esm1p6/atmosphere/amip/cmip7_AM_amip_generate.py
@@ -18,9 +18,7 @@ def parse_args():
     parser = ArgumentParser(
         parents=[path_parser(), grid_parser(), ukesm_parser()],
         prog="cmip7_AM_amip_generate",
-        description=(
-            "Generate input files from UK CMIP7 AMIP forcings"
-        ),
+        description="Generate input files from UK CMIP7 AMIP forcings",
     )
     return parser.parse_args()
 
@@ -45,7 +43,7 @@ def save_cmip7_am_amip(args, cube):
         save_dirpath,
         args.save_filename,
         gregorian=False,
-        replace_bounds=True
+        replace_bounds=True,
     )
 
 

--- a/CMIP7/esm1p6/atmosphere/amip/cmip7_AM_amip_generate.py
+++ b/CMIP7/esm1p6/atmosphere/amip/cmip7_AM_amip_generate.py
@@ -43,7 +43,6 @@ def save_cmip7_am_amip(args, cube):
         save_dirpath,
         args.save_filename,
         gregorian=False,
-        replace_bounds=True,
     )
 
 
@@ -52,7 +51,7 @@ if __name__ == "__main__":
 
     # Load the CMIP7 datasets
     ukesm_cube = load_cmip7_ukesm(args)
-    # Match the ESM1.5 mask but do not zero-fill
+    # Match the ESM1.5 mask coordinates but do not zero-fill
     esm_cube = fix_cmip7_ukesm(args, ukesm_cube, fill=False)
     # Save the ancillary
     save_cmip7_am_amip(args, esm_cube)

--- a/CMIP7/esm1p6/atmosphere/amip/cmip7_AM_amip_generate.py
+++ b/CMIP7/esm1p6/atmosphere/amip/cmip7_AM_amip_generate.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 
     # Load the CMIP7 datasets
     ukesm_cube = load_cmip7_ukesm(args)
-    # Match the ESM1.5 mask
-    esm_cube = fix_cmip7_ukesm(args, ukesm_cube)
+    # Match the ESM1.5 mask but do not zero-fill
+    esm_cube = fix_cmip7_ukesm(args, ukesm_cube, fill=False)
     # Save the ancillary
     save_cmip7_am_amip(args, esm_cube)

--- a/CMIP7/esm1p6/atmosphere/amip/cmip7_AM_amip_generate.py
+++ b/CMIP7/esm1p6/atmosphere/amip/cmip7_AM_amip_generate.py
@@ -1,0 +1,60 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+from cmip7_ancil_argparse import (
+    grid_parser,
+    path_parser,
+)
+from cmip7_ancil_common import save_ancil
+from cmip7_ancil_constants import ANCIL_TODAY
+from cmip7_ancil_ukesm import (
+    fix_cmip7_ukesm,
+    load_cmip7_ukesm,
+    ukesm_parser,
+)
+
+
+def parse_args():
+    parser = ArgumentParser(
+        parents=[path_parser(), grid_parser(), ukesm_parser()],
+        prog="cmip7_AM_amip_generate",
+        description=(
+            "Generate input files from UK CMIP7 AMIP forcings"
+        ),
+    )
+    return parser.parse_args()
+
+
+def esm_am_amip_save_dirpath(args):
+    return (
+        Path(args.ancil_target_dirname)
+        / "modern"
+        / "amip"
+        / "atmosphere"
+        / "boundary_conditions"
+        / args.esm_grid_rel_dirname
+        / ANCIL_TODAY
+    )
+
+
+def save_cmip7_am_amip(args, cube):
+    # Save as an ancillary file
+    save_dirpath = esm_am_amip_save_dirpath(args)
+    save_ancil(
+        cube,
+        save_dirpath,
+        args.save_filename,
+        gregorian=False,
+        replace_bounds=True
+    )
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    # Load the CMIP7 datasets
+    ukesm_cube = load_cmip7_ukesm(args)
+    # Match the ESM1.5 mask
+    esm_cube = fix_cmip7_ukesm(args, ukesm_cube)
+    # Save the ancillary
+    save_cmip7_am_amip(args, esm_cube)

--- a/CMIP7/esm1p6/atmosphere/cmip7_ancil_common.py
+++ b/CMIP7/esm1p6/atmosphere/cmip7_ancil_common.py
@@ -155,9 +155,11 @@ def fix_poles(cube):
     # Polar values should have no longitude dependence
     latdim = cube.coord_dims("latitude")
     assert latdim == (1,)
-    zonal_mean = np.mean(cube.data, axis=0)
-    cube.data[:, 0] = zonal_mean[0]
-    cube.data[:, -1] = zonal_mean[-1]
+    longdim = cube.coord_dims("longitude")
+    assert longdim == (2,)
+    zonal_mean = np.ma.mean(cube.data, axis=2)
+    cube.data[:, 0, :] = zonal_mean[:, [0]]
+    cube.data[:, -1, :] = zonal_mean[:, [-1]]
 
 
 def save_ancil(

--- a/CMIP7/esm1p6/atmosphere/cmip7_ancil_common.py
+++ b/CMIP7/esm1p6/atmosphere/cmip7_ancil_common.py
@@ -151,13 +151,13 @@ def fix_coords(args, cube):
     ).coord_system
 
 
-def zero_poles(cube):
+def fix_poles(cube):
     # Polar values should have no longitude dependence
-    # For aerosol emissions they should be zero
     latdim = cube.coord_dims("latitude")
     assert latdim == (1,)
-    cube.data[:, 0] = 0.0
-    cube.data[:, -1] = 0.0
+    zonal_mean = np.mean(cube.data, axis=0)
+    cube.data[:, 0] = zonal_mean[0]
+    cube.data[:, -1] = zonal_mean[-1]
 
 
 def save_ancil(

--- a/CMIP7/esm1p6/atmosphere/cmip7_ancil_ukesm.py
+++ b/CMIP7/esm1p6/atmosphere/cmip7_ancil_ukesm.py
@@ -2,7 +2,10 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 import iris
-from cmip7_ancil_common import fix_coords
+from cmip7_ancil_common import (
+    fix_coords,
+    fix_poles,
+)
 
 
 def ukesm_parser():
@@ -24,8 +27,10 @@ def load_cmip7_ukesm(args):
     return iris.load_cube(filepath)
 
 
-def fix_cmip7_ukesm(args, cube):
+def fix_cmip7_ukesm(args, cube, fill=True):
     # Make the coordinates compatible with the ESM1.5 grid mask
     fix_coords(args, cube)
-    cube.data = cube.data.filled(0.0)
+    if fill:
+        cube.data = cube.data.filled(0.0)
+    fix_poles(cube)
     return cube

--- a/CMIP7/esm1p6/atmosphere/cmip7_ancil_ukesm.py
+++ b/CMIP7/esm1p6/atmosphere/cmip7_ancil_ukesm.py
@@ -1,0 +1,31 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+import iris
+from cmip7_ancil_common import fix_coords
+
+
+def ukesm_parser():
+    parser = ArgumentParser(add_help=False)
+    parser.add_argument("--ukesm-ancil-dirpath")
+    parser.add_argument("--ukesm-netcdf-filename")
+    parser.add_argument("--save-filename")
+    return parser
+
+
+def cmip7_ukesm_filepath(args):
+    dirpath = Path(args.ukesm_ancil_dirpath)
+    filename = args.ukesm_netcdf_filename
+    return dirpath / filename
+
+
+def load_cmip7_ukesm(args):
+    filepath = cmip7_ukesm_filepath(args)
+    return iris.load_cube(filepath)
+
+
+def fix_cmip7_ukesm(args, cube):
+    # Make the coordinates compatible with the ESM1.5 grid mask
+    fix_coords(args, cube)
+    cube.data = cube.data.filled(0.0)
+    return cube


### PR DESCRIPTION
Closes #121 

See also https://github.com/ACCESS-NRI/CMIP7-Input/tree/scen7-amip
https://github.com/ACCESS-NRI/ancillary-file-science/tree/1-port-cmip7-amip-code-for-esm16-site-nci
https://code.metoffice.gov.uk/trac/roses-u/browser/d/q/8/1/9/cleanup?rev=360148
https://code.metoffice.gov.uk/trac/roses-u/browser/d/q/8/1/9/trunk?rev=360149

This pull request adds the  `cmip7_AM_amip_generate.py` Python code for the `AM_seaice_ancil_amip` and  `AM_sst_ancil_amip` tasks. This code takes the NetCDF files produced by the `AM_ukesm_ancil` and produces the final ancillary files. This code has also been incorporated into the https://github.com/ACCESS-NRI/CMIP7-Input/tree/scen7-amip branch, which includes all changes from https://github.com/ACCESS-NRI/CMIP7-Input/tree/127-n2-and-o3-for-esm16-h-and-vl

The code was tested by running https://code.metoffice.gov.uk/trac/roses-u/browser/d/q/8/1/9/cleanup?rev=360148 which uses the `scne7-amp` branch and produced the files
```
/g/data/tm70/pcl851/CMIP7/esm1p6_ancil/2026.07.02/modern/amip/atmosphere/boundary_conditions/global.N96/2026.07.02/sst_amip_n96_gregorian.anc
/g/data/tm70/pcl851/CMIP7/esm1p6_ancil/2026.07.02/modern/amip/atmosphere/boundary_conditions/global.N96/2026.07.02/seaice_amip_n96_gregorian.anc
```
The run logs are in `/scratch/tm70/pcl851/cylc-run/u-dq819.cleanup/run10/log/job/1/AM_*_ancil_amip/`