### PR TITLE
Process ScenarioMIP forcings for CO2 emissions

### DIFF
--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_SM_aerosol_anthro.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_SM_aerosol_anthro.py
@@ -42,6 +42,16 @@ def _anthro_dirpath(args, variable):
     )
 
 
+def cmip7_sm_aerosol_air_anthro_filepath(args, species, date_range):
+    dirpath = _anthro_dirpath(args, f"{species}_em_AIR_anthro")
+    filename = (
+        f"{species}-em-AIR-anthro_input4MIPs_emissions_ScenarioMIP_"
+        f"{args.dataset_version}_gn_"
+        f"{date_range}.nc"
+    )
+    return dirpath / filename
+
+
 def cmip7_sm_aerosol_anthro_filepath(args, species, date_range):
     dirpath = _anthro_dirpath(args, f"{species}_em_anthro")
     filename = (
@@ -50,6 +60,21 @@ def cmip7_sm_aerosol_anthro_filepath(args, species, date_range):
         f"{date_range}.nc"
     )
     return dirpath / filename
+
+
+def load_cmip7_sm_aerosol_air_anthro(args, species):
+    cube = load_cmip7_aerosol(
+        args,
+        cmip7_sm_aerosol_air_anthro_filepath,
+        species,
+        args.dataset_date_range,
+        cmip7_date_constraint_from_years(CMIP7_SM_BEG_YEAR, CMIP7_SM_END_YEAR),
+    )
+    fix_coords(args, cube)
+    interpolated = interpolate_monthly(
+        cube, CMIP7_SM_BEG_YEAR, CMIP7_SM_END_YEAR
+    )
+    return extend_years(interpolated)
 
 
 def load_cmip7_sm_aerosol_anthro(args, species):

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_SM_aerosol_anthro.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_SM_aerosol_anthro.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 from pathlib import Path
 
+import iris
 from aerosol.cmip7_aerosol_anthro import cmip7_aerosol_anthro_interpolate
 from aerosol.cmip7_aerosol_common import load_cmip7_aerosol
 from aerosol.cmip7_SM_aerosol import esm_sm_aerosol_save_dirpath
@@ -71,13 +72,16 @@ def load_cmip7_sm_aerosol_air_anthro(args, species):
         cmip7_date_constraint_from_years(CMIP7_SM_BEG_YEAR, CMIP7_SM_END_YEAR),
     )
     fix_coords(args, cube)
+    if cube.coords("altitude"):
+        cube = cube.collapsed(["altitude"], iris.analysis.SUM)
+        cube.remove_coord("altitude")
     interpolated = interpolate_monthly(
         cube, CMIP7_SM_BEG_YEAR, CMIP7_SM_END_YEAR
     )
     return extend_years(interpolated)
 
 
-def load_cmip7_sm_aerosol_anthro(args, species):
+def load_cmip7_sm_aerosol_anthro(args, species, collapse_sector=False):
     cube = load_cmip7_aerosol(
         args,
         cmip7_sm_aerosol_anthro_filepath,
@@ -86,6 +90,9 @@ def load_cmip7_sm_aerosol_anthro(args, species):
         cmip7_date_constraint_from_years(CMIP7_SM_BEG_YEAR, CMIP7_SM_END_YEAR),
     )
     fix_coords(args, cube)
+    if collapse_sector and cube.coords("sector"):
+        cube = cube.collapsed(["sector"], iris.analysis.SUM)
+        cube.remove_coord("sector")
     interpolated = interpolate_monthly(
         cube, CMIP7_SM_BEG_YEAR, CMIP7_SM_END_YEAR
     )

--- a/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_anthro.py
+++ b/CMIP7/esm1p6/atmosphere/aerosol/cmip7_aerosol_anthro.py
@@ -67,6 +67,9 @@ def load_cmip7_aerosol_air_anthro_list(
         constraint,
     )
     fix_coords(args, cube)
+    if cube.coords("altitude"):
+        cube = cube.collapsed(["altitude"], iris.analysis.SUM)
+        cube.remove_coord("altitude")
     return cube
 
 

--- a/CMIP7/esm1p6/atmosphere/co2/cmip7_EH_CO2_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/co2/cmip7_EH_CO2_interpolate.py
@@ -43,15 +43,16 @@ def cmip7_eh_co2_anthro_interpolate(args):
         beg_year=CMIP7_HI_CO2_BEG_YEAR,
         end_year=CMIP7_HI_CO2_END_YEAR,
     )
-    cube_sum = cube.collapsed(["sector"], iris.analysis.SUM)
+    if cube.coords("sector"):
+        cube = cube.collapsed(["sector"], iris.analysis.SUM)
+        cube.remove_coord("sector")
     cube_air = load_cmip7_hi_aerosol_air_anthro(
         args,
         SPECIES,
         beg_year=CMIP7_HI_CO2_BEG_YEAR,
         end_year=CMIP7_HI_CO2_END_YEAR,
     )
-    cube_air_sum = cube_air.collapsed(["altitude"], iris.analysis.SUM)
-    cube_tot = cube_sum + cube_air_sum
+    cube_tot = cube + cube_air
 
     esm_cube = cube_tot.regrid(esm_grid_mask_cube(args), INTERPOLATION_SCHEME)
     esm_cube.data = esm_cube.data.filled(0.0)

--- a/CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py
@@ -1,0 +1,70 @@
+# Interpolate CMIP7 ES CO2 emissions to ESM1.6 grid
+from argparse import ArgumentParser
+from pathlib import Path
+
+import iris
+from aerosol.cmip7_aerosol_common import zero_poles
+from aerosol.cmip7_SM_aerosol_anthro import (
+    load_cmip7_sm_aerosol_air_anthro,
+    load_cmip7_sm_aerosol_anthro,
+)
+from cmip7_ancil_argparse import common_parser
+from cmip7_ancil_common import (
+    INTERPOLATION_SCHEME,
+    esm_grid_mask_cube,
+    save_ancil,
+)
+from cmip7_ancil_constants import ANCIL_TODAY
+
+SPECIES = "CO2"
+STASH_ITEM = 251
+
+
+def parse_args():
+    parser = ArgumentParser(
+        prog=f"cmip7_ES_{SPECIES}_interpolate",
+        description=(
+            f"Generate input files from CMIP7 ScenarioMIP {SPECIES} forcings"
+        ),
+        parents=[common_parser()],
+    )
+    parser.add_argument("--scenario")
+    parser.add_argument("--dataset-date-range")
+    parser.add_argument("--save-filename")
+    return parser.parse_args()
+
+
+def esm_es_co2_save_dirpath(args):
+    return (
+        Path(args.ancil_target_dirname)
+        / "esm-scenarios"
+        / args.scenario
+        / "atmosphere"
+        / "forcing"
+        / args.esm_grid_rel_dirname
+        / ANCIL_TODAY
+    )
+
+
+def cmip7_es_co2_anthro_interpolate(args):
+    cube = load_cmip7_sm_aerosol_anthro(args, SPECIES)
+    cube_sum = cube.collapsed(["sector"], iris.analysis.SUM)
+    cube_air = load_cmip7_sm_aerosol_air_anthro(args, SPECIES)
+    cube_air_sum = cube_air.collapsed(["altitude"], iris.analysis.SUM)
+    cube_tot = cube_sum + cube_air_sum
+
+    esm_cube = cube_tot.regrid(esm_grid_mask_cube(args), INTERPOLATION_SCHEME)
+    esm_cube.data = esm_cube.data.filled(0.0)
+    zero_poles(esm_cube)
+    esm_cube.attributes["STASH"] = iris.fileformats.pp.STASH(
+        model=1, section=0, item=STASH_ITEM
+    )
+
+    save_dirpath = esm_es_co2_save_dirpath(args)
+    save_ancil(esm_cube, save_dirpath, args.save_filename)
+
+
+if __name__ == "__main__":
+    args = parse_args(species=SPECIES)
+
+    cmip7_es_co2_anthro_interpolate(args)

--- a/CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py
@@ -47,33 +47,19 @@ def esm_es_co2_save_dirpath(args):
 
 
 def cmip7_es_co2_anthro_interpolate(args):
-    print(49)
-    cube = load_cmip7_sm_aerosol_anthro(args, SPECIES)
-    print(51)
-    cube_sum = cube.collapsed(["sector"], iris.analysis.SUM)
-    print(53)
+    cube = load_cmip7_sm_aerosol_anthro(args, SPECIES, collapse_sector=True)
     cube_air = load_cmip7_sm_aerosol_air_anthro(args, SPECIES)
-    print(55)
-    cube_air_sum = cube_air.collapsed(["altitude"], iris.analysis.SUM)
-    print(57)
-    cube_tot = cube_sum + cube_air_sum
-    print(59)
+    cube_tot = cube + cube_air
 
     esm_cube = cube_tot.regrid(esm_grid_mask_cube(args), INTERPOLATION_SCHEME)
-    print(62)
     esm_cube.data = esm_cube.data.filled(0.0)
-    print(65)
     zero_poles(esm_cube)
-    print(67)
     esm_cube.attributes["STASH"] = iris.fileformats.pp.STASH(
         model=1, section=0, item=STASH_ITEM
     )
-    print(70)
 
     save_dirpath = esm_es_co2_save_dirpath(args)
-    print(73)
     save_ancil(esm_cube, save_dirpath, args.save_filename)
-    print(75)
 
 
 if __name__ == "__main__":

--- a/CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py
@@ -65,6 +65,6 @@ def cmip7_es_co2_anthro_interpolate(args):
 
 
 if __name__ == "__main__":
-    args = parse_args(species=SPECIES)
+    args = parse_args()
 
     cmip7_es_co2_anthro_interpolate(args)

--- a/CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py
+++ b/CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py
@@ -47,21 +47,33 @@ def esm_es_co2_save_dirpath(args):
 
 
 def cmip7_es_co2_anthro_interpolate(args):
+    print(49)
     cube = load_cmip7_sm_aerosol_anthro(args, SPECIES)
+    print(51)
     cube_sum = cube.collapsed(["sector"], iris.analysis.SUM)
+    print(53)
     cube_air = load_cmip7_sm_aerosol_air_anthro(args, SPECIES)
+    print(55)
     cube_air_sum = cube_air.collapsed(["altitude"], iris.analysis.SUM)
+    print(57)
     cube_tot = cube_sum + cube_air_sum
+    print(59)
 
     esm_cube = cube_tot.regrid(esm_grid_mask_cube(args), INTERPOLATION_SCHEME)
+    print(62)
     esm_cube.data = esm_cube.data.filled(0.0)
+    print(65)
     zero_poles(esm_cube)
+    print(67)
     esm_cube.attributes["STASH"] = iris.fileformats.pp.STASH(
         model=1, section=0, item=STASH_ITEM
     )
+    print(70)
 
     save_dirpath = esm_es_co2_save_dirpath(args)
+    print(73)
     save_ancil(esm_cube, save_dirpath, args.save_filename)
+    print(75)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #140 

For each scenario, the code in CMIP7/esm1p6/atmosphere/co2/cmip7_ES_CO2_interpolate.py reads both the ScenarioMIP CO2 emission forcing data for CO2 and the ScenarioMIP aircraft CO2 emission forcing data, adds the two, then interpolates the time series and regrids the data to produce an ancillary file.

It turns out that the equivalent code in
CMIP7/esm1p6/atmosphere/co2/cmip7_EH_CO2_interpolate.py for the historical forcings interpolated monthly data from the cubes corresponding the the historical forcing data *before* collapsing the CO2 emission data by sector and the CO2 aircraft emsiion data by altitude. When this was tried for ScenarioMIP the task ran out of memory when interpolating the time series. The solution applied to both the `EH` and `ES` code is to collapse the respective cubes before interpolating the time series. That is why four files are changed.  